### PR TITLE
Added an option to hide the label on the gauge.

### DIFF
--- a/libs/ngx-gauge/src/gauge/gauge.html
+++ b/libs/ngx-gauge/src/gauge/gauge.html
@@ -1,5 +1,7 @@
-<div class="reading-block" #reading [style.fontSize]="size * 0.22 + 'px'" [style.lineHeight]="size + 'px'">
-    <u class="reading-affix">{{prepend}}</u>{{value | number}}<u class="reading-affix">{{append}}</u>
-</div>
-<div class="reading-label" [style.fontSize]="size / 13 + 'px'" [style.lineHeight]="(5 * size / 13) + size + 'px'">{{label}}</div>
+<ng-container *ngIf="showLabel">
+  <div class="reading-block" #reading [style.fontSize]="size * 0.22 + 'px'" [style.lineHeight]="size + 'px'">
+      <u class="reading-affix">{{prepend}}</u>{{value | number}}<u class="reading-affix">{{append}}</u>
+  </div>
+  <div class="reading-label" [style.fontSize]="size / 13 + 'px'" [style.lineHeight]="(5 * size / 13) + size + 'px'">{{label}}</div>
+</ng-container>
 <canvas #canvas [width]="size" [height]="size"></canvas>

--- a/libs/ngx-gauge/src/gauge/gauge.ts
+++ b/libs/ngx-gauge/src/gauge/gauge.ts
@@ -89,6 +89,8 @@ export class NgxGauge implements AfterViewInit, OnChanges, OnDestroy {
 
     @Input() thresholds: Object = Object.create(null);
 
+    @Input() showLabel: boolean = true;
+
     private _value: number = 0;
 
     @Input()
@@ -171,6 +173,8 @@ export class NgxGauge implements AfterViewInit, OnChanges, OnDestroy {
     }
 
     private _clear() {
+        if (this._context == null)
+            return;
         this._context.clearRect(0, 0, this._getWidth(), this._getHeight());
     }
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@angular/compiler-cli": "5.1.0",
     "@angular/language-service": "5.1.0",
     "@nrwl/schematics": "0.6.0",
+    "@angular-devkit/core": "0.0.29",
     "@types/jasmine": "~2.5.53",
     "@types/jasminewd2": "~2.0.2",
     "@types/node": "~6.0.60",


### PR DESCRIPTION
I have a use case where I just want to display the gauge, no label.

I also slipped in a small bug fix that I've been seeing in my app. Sometimes _context is null in that clear method and it throws an error.