### PR TITLE
Fix negative threshold backgrounds not rendering (Issue #159)

### DIFF
--- a/apps/demo/src/app/demos/demos.component.html
+++ b/apps/demo/src/app/demos/demos.component.html
@@ -310,4 +310,55 @@
       </div>
     </div>
   </div>
+
+  <div class="column-box">
+
+    <div class="column-item">
+      <mat-tab-group dynamicHeight="true">
+        <mat-tab label="Description">
+          <div class="content">
+            <h4>Negative Range with Threshold Backgrounds</h4>
+            <p>
+              Gauges now support negative ranges with threshold backgrounds! This example demonstrates a gauge
+              ranging from -100 to +100 with colored threshold backgrounds across the entire range,
+              including negative values.
+            </p>
+            <p>
+              <strong>Threshold ranges:</strong>
+            </p>
+            <ul style="font-family: monospace; font-size: 14px;">
+              <li style="color: #ff0000;">-100 to -80: Red</li>
+              <li style="color: #ff9800;">-80 to -60: Orange</li>
+              <li style="color: #ffeb3b;">-60 to 0: Yellow</li>
+              <li style="color: #4caf50;">0 to 60: Green</li>
+              <li style="color: #2196f3;">60 to 80: Blue</li>
+              <li style="color: #9c27b0;">80 to 100: Purple</li>
+            </ul>
+            <button mat-raised-button color="accent" (click)="onNegativeUpdateClick()">Update Value</button>
+          </div>
+        </mat-tab>
+        <mat-tab label="Markup">
+          <div class="content">
+            This is the code for the demo shown on the right:
+
+            <pre [highlight]="negativeThresholdMarkup"></pre>
+          </div>
+        </mat-tab>
+        <mat-tab label="TypeScript">
+          <div class="content">
+            This is the code for the demo shown on the right:
+
+            <pre [highlight]="negativeThresholdTS"></pre>
+          </div>
+        </mat-tab>
+      </mat-tab-group>
+    </div>
+    <div class="column-item">
+      <div class="output-frame">
+        <ngx-gauge size="220" type="arch" thick="20" [value]="negativeThresholdValue" min="-100" max="100" cap="butt" label="Temperature" append="°C" [thresholds]="negativeThresholdConfig">
+        </ngx-gauge>
+        <p style="margin-top: 15px;"><strong>Current Value: {{ negativeThresholdValue }}°C</strong></p>
+      </div>
+    </div>
+  </div>
 </div>

--- a/apps/demo/src/app/demos/demos.component.ts
+++ b/apps/demo/src/app/demos/demos.component.ts
@@ -161,6 +161,41 @@ export class DemosComponent {
 
 }`
 
+const negativeThresholdMarkup = `<ngx-gauge size="220"
+           type="arch"
+           thick="20"
+           value="-45"
+           min="-100"
+           max="100"
+           cap="butt"
+           label="Temperature"
+           append="°C"
+           [thresholds]="negativeThresholdConfig">
+</ngx-gauge>
+`;
+
+const negativeThresholdTS = `import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-demos',
+  templateUrl: './demos.component.html',
+  styleUrls: ['./demos.component.css']
+})
+export class DemosComponent {
+
+  constructor() { }
+
+  negativeThresholdConfig = {
+    "-100": { color: '#ff0000', bgOpacity: 0.2 },
+    "-80": { color: '#ff9800', bgOpacity: 0.2 },
+    "-60": { color: '#ffeb3b', bgOpacity: 0.2 },
+    "0": { color: '#4caf50', bgOpacity: 0.2 },
+    "60": { color: '#2196f3', bgOpacity: 0.2 },
+    "80": { color: '#9c27b0', bgOpacity: 0.2 }
+  }
+
+}`
+
 @Component({
     selector: 'app-demos',
     templateUrl: './demos.component.html',
@@ -189,6 +224,8 @@ export class DemosComponent implements OnInit {
   customMarkup2 = customMarkup2;
   gaugeWithMarkerMarkup = gaugeWithMarkerMarkup;
   gaugeWithMarkerTS = gaugeWithMarkersTS;
+  negativeThresholdMarkup = negativeThresholdMarkup;
+  negativeThresholdTS = negativeThresholdTS;
   markerConfig = {
     "0": { color: '#555', size: 8, label: '0', type: 'line'},
     "15": { color: '#555', size: 4, type: 'line'},
@@ -201,10 +238,24 @@ export class DemosComponent implements OnInit {
     "100": { color: '#555', size: 8, label: '100', type: 'line'},
 }
 
+  negativeThresholdConfig = {
+    "-100": { color: '#ff0000', bgOpacity: 0.2 },
+    "-80": { color: '#ff9800', bgOpacity: 0.2 },
+    "-60": { color: '#ffeb3b', bgOpacity: 0.2 },
+    "0": { color: '#4caf50', bgOpacity: 0.2 },
+    "60": { color: '#2196f3', bgOpacity: 0.2 },
+    "80": { color: '#9c27b0', bgOpacity: 0.2 }
+  }
+
   dynamicGaugeDemoValue = 10.2;
+  negativeThresholdValue = -45;
 
   onUpdateClick() {
     this.dynamicGaugeDemoValue = Math.round(Math.random() * 1000)/10;
+  }
+
+  onNegativeUpdateClick() {
+    this.negativeThresholdValue = Math.floor(Math.random() * 201) - 100; // Random value from -100 to 100
   }
 
 }

--- a/projects/ngx-gauge/src/gauge/gauge.ts
+++ b/projects/ngx-gauge/src/gauge/gauge.ts
@@ -437,7 +437,7 @@ export class NgxGauge implements AfterViewInit, OnChanges, OnDestroy, OnInit {
 
     private _getBackgroundColorRanges() {
 
-        let i = 0,ranges = [];
+        let i = this.min,ranges = [];
         do {
             let thresh = this._getThresholdMatchForValue(i);
             if (thresh) {

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,23 +1,51 @@
 <!--The content below is only a placeholder and can be replaced.-->
-<div style="text-align:center">
-  <h1>
-    Welcome to {{ title }}!
-  </h1>
-  <img width="300" alt="Angular Logo" src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTAgMjUwIj4KICAgIDxwYXRoIGZpbGw9IiNERDAwMzEiIGQ9Ik0xMjUgMzBMMzEuOSA2My4ybDE0LjIgMTIzLjFMMTI1IDIzMGw3OC45LTQzLjcgMTQuMi0xMjMuMXoiIC8+CiAgICA8cGF0aCBmaWxsPSIjQzMwMDJGIiBkPSJNMTI1IDMwdjIyLjItLjFWMjMwbDc4LjktNDMuNyAxNC4yLTEyMy4xTDEyNSAzMHoiIC8+CiAgICA8cGF0aCAgZmlsbD0iI0ZGRkZGRiIgZD0iTTEyNSA1Mi4xTDY2LjggMTgyLjZoMjEuN2wxMS43LTI5LjJoNDkuNGwxMS43IDI5LjJIMTgzTDEyNSA1Mi4xem0xNyA4My4zaC0zNGwxNy00MC45IDE3IDQwLjl6IiAvPgogIDwvc3ZnPg==">
+<div style="text-align:center; padding: 20px;">
+  <h1>ngx-gauge Demo</h1>
+
+  <div style="margin: 40px 0;">
+    <h2>Issue #159 Fix: Negative Threshold Backgrounds</h2>
+    <p style="max-width: 600px; margin: 0 auto;">
+      This gauge demonstrates the fix for negative threshold backgrounds.
+      The gauge ranges from -100 to +100 with colored threshold backgrounds across the full range.
+    </p>
+    <div style="margin: 20px 0;">
+      <ngx-gauge
+        [type]="'arch'"
+        [value]="negativeTestValue"
+        [min]="-100"
+        [max]="100"
+        [thick]="20"
+        [thresholds]="negativeThresholds"
+        [label]="'Temperature'"
+        [append]="'°C'">
+      </ngx-gauge>
+      <p style="margin-top: 10px;">
+        <strong>Current Value: {{ negativeTestValue }}</strong>
+      </p>
+      <button (click)="changeNegativeValue()" style="padding: 10px 20px; font-size: 16px;">
+        Change Value
+      </button>
+    </div>
+    <div style="margin-top: 20px; text-align: left; max-width: 600px; margin: 20px auto; background: #f5f5f5; padding: 15px; border-radius: 5px;">
+      <h3>Threshold Configuration:</h3>
+      <ul style="font-family: monospace; font-size: 14px;">
+        <li style="color: #ff0000;">-100 to -80: Red (bgOpacity: 0.2)</li>
+        <li style="color: #ff9800;">-80 to -60: Orange (bgOpacity: 0.2)</li>
+        <li style="color: #ffeb3b;">-60 to 0: Yellow (bgOpacity: 0.2)</li>
+        <li style="color: #4caf50;">0 to 60: Green (bgOpacity: 0.2)</li>
+        <li style="color: #2196f3;">60 to 80: Blue (bgOpacity: 0.2)</li>
+        <li style="color: #9c27b0;">80 to 100: Purple (bgOpacity: 0.2)</li>
+      </ul>
+      <p><strong>Expected Result:</strong> All threshold backgrounds should be visible, including the negative ones.</p>
+    </div>
+  </div>
+
+  <hr style="margin: 40px 0;">
+
+  <div style="margin: 40px 0;">
+    <h2>Standard Gauge (Positive Range)</h2>
+    <ngx-gauge [value]="currentValue" [label]="'Progress'"></ngx-gauge>
+    <button (click)="changeValue()" style="margin-top: 10px; padding: 10px 20px; font-size: 16px;">Change</button>
+  </div>
 </div>
-<h2>Here are some links to help you start: </h2>
-<ul>
-  <li>
-    <h2><a target="_blank" rel="noopener" href="https://angular.io/tutorial">Tour of Heroes</a></h2>
-  </li>
-  <li>
-    <h2><a target="_blank" rel="noopener" href="https://angular.io/cli">CLI Documentation</a></h2>
-  </li>
-  <li>
-    <h2><a target="_blank" rel="noopener" href="https://blog.angular.io/">Angular blog</a></h2>
-  </li>
-</ul>
-<ngx-gauge [value]="currentValue" [label]="'Label'"></ngx-gauge>
-<button (click)="changeValue()">change</button>
-<input type="checkbox" #checkbox>
 <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,13 +9,35 @@ export class AppComponent implements OnInit {
   title = 'demo';
   currentValue: number = 0;
   time = 700;
+
+  // Test for issue #159 - Negative threshold backgrounds
+  negativeTestValue: number = -50;
+  negativeThresholds = {
+    '-100': { color: '#ff0000', bgOpacity: 0.2 },  // Red background for -100 to -80
+    '-80': { color: '#ff9800', bgOpacity: 0.2 },   // Orange background for -80 to -60
+    '-60': { color: '#ffeb3b', bgOpacity: 0.2 },   // Yellow background for -60 to 0
+    '0': { color: '#4caf50', bgOpacity: 0.2 },     // Green background for 0 to 60
+    '60': { color: '#2196f3', bgOpacity: 0.2 },    // Blue background for 60 to 80
+    '80': { color: '#9c27b0', bgOpacity: 0.2 }     // Purple background for 80 to 100
+  };
+
   changeValue() {
     //nothing
+  }
+
+  changeNegativeValue() {
+    // Cycle through values to test all threshold ranges
+    this.negativeTestValue = Math.floor(Math.random() * 201) - 100; // Random value from -100 to 100
   }
 
   ngOnInit() {
     setInterval(() => {
       this.currentValue = Math.floor(Math.random() * 100);
     }, this.time);
+
+    // Auto-cycle negative test value
+    setInterval(() => {
+      this.changeNegativeValue();
+    }, 2000);
   }
 }


### PR DESCRIPTION
This commit fixes a bug where threshold backgrounds were not being rendered for thresholds in the negative range of a gauge.

Problem:
- The _getBackgroundColorRanges() method started iterating from 0
- For gauges with negative ranges (e.g., min=-100, max=100), this caused all negative thresholds to be skipped
- Only positive threshold backgrounds were rendered

Solution:
- Changed the initial loop value from 0 to this.min
- Now the method correctly processes all thresholds from the minimum value to the maximum value, including negative ranges

Testing:
- Added comprehensive demo in apps/demo showing negative thresholds
- Both demos show gauges with ranges from -100 to +100 with six colored threshold backgrounds across the full range

Fixes #159