### PR TITLE
chore(release): prepare 13.2.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release
+
+# Publishes the ngx-gauge library to npm when a GitHub Release is published.
+#
+# How to cut a release:
+#   1. Merge a release-prep PR that bumps projects/ngx-gauge/package.json
+#      version and updates CHANGELOG.md.
+#   2. On master, draft a new GitHub Release with tag `v<version>`
+#      (e.g. `v13.2.0`). The tag must match the version in
+#      projects/ngx-gauge/package.json or this workflow will fail.
+#   3. Publish the Release — this workflow runs and publishes to npm.
+#
+# Required repository secret:
+#   NPM_TOKEN — an npm "Automation" granular access token scoped to publish
+#               the `ngx-gauge` package.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    name: Build, verify & publish to npm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write  # required for npm provenance
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify release tag matches package.json version
+        if: github.event_name == 'release'
+        run: |
+          PKG_VERSION="$(node -p "require('./projects/ngx-gauge/package.json').version")"
+          TAG="${GITHUB_REF_NAME}"
+          EXPECTED="v${PKG_VERSION}"
+          if [ "${TAG}" != "${EXPECTED}" ]; then
+            echo "::error::Release tag '${TAG}' does not match package version '${EXPECTED}'."
+            echo "Update projects/ngx-gauge/package.json or rename the release tag."
+            exit 1
+          fi
+          echo "Tag ${TAG} matches package version ${PKG_VERSION}."
+
+      - name: Build library
+        run: npm run build:lib
+
+      - name: Test library
+        run: npm run test:ci
+
+      - name: Publish to npm
+        run: npm publish dist/ngx-gauge --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to **ngx-gauge** will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [13.2.0] - 2026-06-10
+
+### Added
+- Public type exports for stronger consumer typing — these can now be imported
+  from `ngx-gauge` and used to type your own variables:
+  - `NgxGaugeType` — `'full' | 'arch' | 'semi'`
+  - `NgxGaugeCap` — `'round' | 'butt'`
+  - `NgxGaugeThreshold` — shape of a single threshold entry (`color?`, `backgroundColor?`, `bgOpacity?`)
+  - `NgxGaugeThresholds` — `Record<string, NgxGaugeThreshold>`
+  - `NgxGaugeMarker` — shape of a single marker entry (`color?`, `type?`, `size?`, `label?`, `font?`)
+  - `NgxGaugeMarkers` — `Record<string, NgxGaugeMarker>`
+
+### Changed
+- **Repository housekeeping** (invisible to npm consumers — no runtime/API impact):
+  - Aligned workspace layout with the standard Angular CLI library convention:
+    demo app moved from `apps/demo/` to `projects/demo/`, library barrel renamed
+    `public_api.ts` → `public-api.ts`, polyfills inlined in `angular.json` as
+    `["zone.js"]`, `environments/` + `fileReplacements` removed, static assets
+    moved to `projects/demo/public/`, manual `enableProdMode()` dropped (the
+    application builder handles this automatically). (#200)
+  - Lint cleanup across the library and demo; lint is now gated in CI. (#199)
+  - Removed unused dead code and stale configuration. (#198)
+  - Added GitHub Actions CI workflow with Node 20/22 build & test matrix, plus
+    Dependabot grouping for npm + Actions updates. (#193)
+
+### Notes
+- The compiled `dist/ngx-gauge` output is byte-identical to `13.1.0` except for
+  one renamed `sources` entry in the `.mjs.map` file (`public_api.ts` →
+  `public-api.ts`). Runtime behaviour is unchanged.
+- `@Input` types for `thresholds` and `markers` remain `Object` in this
+  release; the corresponding type-tightening change is bundled with the
+  upcoming `14.0.0` modernization release alongside other breaking changes.
+
+## [13.1.0] - earlier
+
+See the [GitHub Releases](https://github.com/ashish-chopra/ngx-gauge/releases)
+page for the history of releases prior to `13.2.0`.
+
+[Unreleased]: https://github.com/ashish-chopra/ngx-gauge/compare/v13.2.0...HEAD
+[13.2.0]: https://github.com/ashish-chopra/ngx-gauge/compare/v13.1.0...v13.2.0
+[13.1.0]: https://github.com/ashish-chopra/ngx-gauge/releases/tag/v13.1.0

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2018-2021 Ashish Chopra
+Copyright (c) 2017-2026 Ashish Chopra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In version `v5.0.0`, we introduced markers, ticks and background opacity for gau
 |18.x.x | 10.0.0 |
 |19.x.x | 11.0.0 |
 |20.x.x | 12.0.0 |
-|21.x.x | 13.0.0 |
+|21.x.x | 13.2.0 |
 
 #### Step 1: Install npm module
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "ng serve",
     "start:lib": "ng build ngx-gauge --watch --configuration=development",
     "build": "ng build",
-    "build:lib": "ng build ngx-gauge --configuration=production",
+    "build:lib": "ng build ngx-gauge --configuration=production && cp README.md LICENSE.md CHANGELOG.md dist/ngx-gauge/",
     "build:demo": "ng build --configuration=production --base-href=/ngx-gauge/",
     "predeploy": "npm run build:lib && npm run build:demo",
     "deploy": "npx angular-cli-ghpages --dir=dist/demo/browser",

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -45,7 +45,7 @@
   <footer>
     <div class="container footer-box">
       <div>
-        <div>&copy; copyright 2017-2021 Ashish Chopra.
+        <div>&copy; copyright 2017-2026 Ashish Chopra.
           <br> <br><br> Thanks to <b> GitHub &middot; Angular &middot; Highlightjs &middot; Bootstrap 4 &middot; Font
             Awesome</b> for giving technologies to build this website.
           <br> Thanks to <a href="https://github.com/pixelsyndicate" target="_blank">Wil Dobson</a> for contributing the

--- a/projects/ngx-gauge/package.json
+++ b/projects/ngx-gauge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-gauge",
-    "version": "13.1.0",
+    "version": "13.2.0",
     "description": "A highly customizable Gauge Component for Angular 4+ apps and dashboards",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Adds release infrastructure and bumps the library to 13.2.0.

- Bump projects/ngx-gauge/package.json: 13.1.0 -> 13.2.0
- Add CHANGELOG.md (Keep a Changelog format) with 13.2.0 entry covering the 6 new public type exports (NgxGaugeType, NgxGaugeCap, NgxGaugeThreshold, NgxGaugeThresholds, NgxGaugeMarker, NgxGaugeMarkers) and the repo-housekeeping landed since v13.1.0 (#193, #198, #199, #200)
- Add .github/workflows/release.yml: triggers on GitHub Release published, verifies tag matches package version, builds + tests + publishes to npm with --provenance --access public (requires NPM_TOKEN secret)
- Extend build:lib script to copy README.md, LICENSE.md and CHANGELOG.md into dist/ngx-gauge so they are bundled in the published tarball and the README renders on the npmjs.com package page
- README: update Angular 21.x.x compat row from 13.0.0 -> 13.2.0
- LICENSE: update copyright year range to 2017-2026
- Demo footer: update copyright year range to 2018-2026

Note: @Input type tightening for thresholds/markers is intentionally deferred to 14.0.0 and bundled with the standalone/inject/signals modernization.