### PR TITLE
chore(deps): bump rxjs to 7.8.2 and zone.js to 0.16.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,9 +19,9 @@
         "@angular/platform-browser-dynamic": "^21.1.3",
         "@angular/router": "^21.1.3",
         "ngx-highlightjs": "^5.0.0",
-        "rxjs": "~6.6.6",
+        "rxjs": "~7.8.2",
         "tslib": "^2.4.0",
-        "zone.js": "^0.15.0"
+        "zone.js": "~0.16.2"
       },
       "devDependencies": {
         "@angular-eslint/builder": "^21.2.0",
@@ -293,16 +293,6 @@
         "yarn": ">= 1.13.0"
       }
     },
-    "node_modules/@angular-devkit/architect/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@angular-devkit/core": {
       "version": "21.2.15",
       "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-21.2.15.tgz",
@@ -331,16 +321,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/core/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/@angular-devkit/schematics": {
       "version": "21.2.15",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-21.2.15.tgz",
@@ -358,16 +338,6 @@
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/@angular-eslint/builder": {
@@ -11619,16 +11589,6 @@
         "node": ">=20"
       }
     },
-    "node_modules/ng-packagr/node_modules/rxjs": {
-      "version": "7.8.2",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/ngx-highlightjs": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ngx-highlightjs/-/ngx-highlightjs-5.0.0.tgz",
@@ -13195,22 +13155,13 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "license": "0BSD"
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.4",
@@ -15474,9 +15425,9 @@
       }
     },
     "node_modules/zone.js": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
-      "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.16.2.tgz",
+      "integrity": "sha512-Eky7p2Z1Ig3NnbfodSPoARCjKBSTFMnE/ACsP1L/XJEfY4SdOFce19BsUCWVwL6K5ABZFy5J3bjcMWffX+YM3Q==",
       "license": "MIT"
     }
   }

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
     "@angular/platform-browser-dynamic": "^21.1.3",
     "@angular/router": "^21.1.3",
     "ngx-highlightjs": "^5.0.0",
-    "rxjs": "~6.6.6",
+    "rxjs": "~7.8.2",
     "tslib": "^2.4.0",
-    "zone.js": "^0.15.0"
+    "zone.js": "~0.16.2"
   },
   "devDependencies": {
     "@angular-eslint/builder": "^21.2.0",


### PR DESCRIPTION
Both upgrades are accepted by the existing Angular 21 peer ranges:

  @angular/core@21 peers:
    rxjs:    ^6.5.3 || ^7.4.0
    zone.js: ~0.15.0 || ~0.16.0

The library has zero rxjs imports and the demo app has zero rxjs imports — only the Angular framework itself uses rxjs at runtime, so this is a transparent runtime upgrade.

Closes Dependabot PRs:
- #211 (rxjs 6 -> 7)
- #212 (zone.js 0.15 -> 0.16)

Verified locally:
- npm run lint              (0 errors)
- npm run test:ci           (41/41 pass)
- npm run build:lib         (success)
- npm run build             (success, demo)