### PR TITLE
chore(deps): bump ngx-highlightjs from 5.0.0 to 14.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@angular/platform-browser": "^21.1.3",
         "@angular/platform-browser-dynamic": "^21.1.3",
         "@angular/router": "^21.1.3",
-        "ngx-highlightjs": "^5.0.0",
+        "ngx-highlightjs": "^14.0.1",
         "rxjs": "~7.8.2",
         "tslib": "^2.4.0",
         "zone.js": "~0.16.2"
@@ -8938,12 +8938,6 @@
         "node": ">=12.0.0"
       }
     },
-    "node_modules/highlightjs-line-numbers.js": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/highlightjs-line-numbers.js/-/highlightjs-line-numbers.js-2.9.1.tgz",
-      "integrity": "sha512-OVLCl58g9hvY11jDCMDjyIM1HcWtElogmRpBBVb0KxMDXxtket58iHA4ex8HCWmQuR1rorYWkQ+4wn3S2T+xlg==",
-      "license": "MIT"
-    },
     "node_modules/hono": {
       "version": "4.12.25",
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
@@ -11590,19 +11584,19 @@
       }
     },
     "node_modules/ngx-highlightjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ngx-highlightjs/-/ngx-highlightjs-5.0.0.tgz",
-      "integrity": "sha512-EZ390iBJdjHcyD7659pJcEcbAARWyt4c7/Oru6SEDgAC9nz8TQOFmgDCvGuYHpwEORcw3g4adZOUf7COrsuTOw==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/ngx-highlightjs/-/ngx-highlightjs-14.0.1.tgz",
+      "integrity": "sha512-pa4YPChIho+Qs6P036oMvTt8pmTlMwberz/kGBojKVMEHSj9t4PT1YzBplM+RMK0VWgLK4zRbJbxivQrLPr1fQ==",
       "license": "MIT",
       "dependencies": {
-        "highlight.js": ">=11.0.0",
-        "highlightjs-line-numbers.js": "^2.8.0",
-        "tslib": "^2.0.0"
+        "highlight.js": "^11.11.1",
+        "tslib": "^2.3.0"
       },
       "peerDependencies": {
-        "@angular/common": ">=12.0.0",
-        "@angular/core": ">=12.0.0",
-        "rxjs": ">=6.0.0"
+        "@angular/cdk": ">=19.0.0",
+        "@angular/common": ">=19.0.0",
+        "@angular/core": ">=19.0.0",
+        "rxjs": ">=7.0.0"
       }
     },
     "node_modules/node-addon-api": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@angular/platform-browser": "^21.1.3",
     "@angular/platform-browser-dynamic": "^21.1.3",
     "@angular/router": "^21.1.3",
-    "ngx-highlightjs": "^5.0.0",
+    "ngx-highlightjs": "^14.0.1",
     "rxjs": "~7.8.2",
     "tslib": "^2.4.0",
     "zone.js": "~0.16.2"

--- a/projects/demo/src/app/app.module.ts
+++ b/projects/demo/src/app/app.module.ts
@@ -53,7 +53,6 @@ import { MatTabsModule } from '@angular/material/tabs';
       provide: HIGHLIGHT_OPTIONS,
       useValue: {
         coreLibraryLoader: () => import('highlight.js/lib/core'),
-        lineNumbersLoader: () => import('highlightjs-line-numbers.js'),
         languages: {
           typescript: () => import('highlight.js/lib/languages/typescript'),
           css: () => import('highlight.js/lib/languages/css'),

--- a/projects/demo/src/app/demos/demos.component.html
+++ b/projects/demo/src/app/demos/demos.component.html
@@ -15,7 +15,7 @@
             <p>Gauge has many default options. With bare minimum required parameters set, you will get a
               ready-to-use gauge as shown.
             </p>
-            <pre [highlight]="intelligentDefaults1"></pre>
+            <pre [highlightAuto]="intelligentDefaults1"></pre>
             <p>To know about default parameters, checkout <a href="#documentation"
             target="_self">documentation</a>.</p>
           </div>
@@ -25,7 +25,7 @@
             <p>We can, however set some more bits to the default code to make it more usable (readable) in
               our apps,
               like:
-              <pre [highlight]="intelligentDefaults2"></pre>
+              <pre [highlightAuto]="intelligentDefaults2"></pre>
               <button mat-raised-button color="accent" (click)="showNewGauge = true">Run</button>
             </div>
           </mat-tab>
@@ -59,7 +59,7 @@
           </mat-tab>
           <mat-tab label="Markup">
             <div class="content">
-              <pre [highlight]="gaugeType1"></pre>
+              <pre [highlightAuto]="gaugeType1"></pre>
             </div>
           </mat-tab>
         </mat-tab-group>
@@ -92,7 +92,7 @@
           </mat-tab>
           <mat-tab label="Markup">
             <div class="content">
-              <pre [highlight]="gaugeStyle1"></pre>
+              <pre [highlightAuto]="gaugeStyle1"></pre>
             </div>
           </mat-tab>
 
@@ -120,7 +120,7 @@
           </mat-tab>
           <mat-tab label="Markup">
             <div class="content">
-              <pre [highlight]="gaugeThickness1"></pre>
+              <pre [highlightAuto]="gaugeThickness1"></pre>
             </div>
           </mat-tab>
         </mat-tab-group>
@@ -153,7 +153,7 @@
           </mat-tab>
           <mat-tab label="Markup">
             <div class="content">
-              <pre [highlight]="gaugeScale1"></pre>
+              <pre [highlightAuto]="gaugeScale1"></pre>
             </div>
           </mat-tab>
         </mat-tab-group>
@@ -182,11 +182,11 @@
           </mat-tab>
           <mat-tab label="Markup">
             <div class="content">
-              <pre [highlight]="dynamicGaugeDemoMarkup1"></pre>
+              <pre [highlightAuto]="dynamicGaugeDemoMarkup1"></pre>
             </div>
             <mat-tab label="TypeScript">
               <div class="content">
-                <pre [highlight]="dynamicGaugeDemoTS1"></pre>
+                <pre [highlightAuto]="dynamicGaugeDemoTS1"></pre>
               </div>
             </mat-tab>
           </mat-tab>
@@ -221,7 +221,7 @@
         </mat-tab>
         <mat-tab label="Markup">
           <div class="content">
-            <pre [highlight]="themesMarkup1"></pre>
+            <pre [highlightAuto]="themesMarkup1"></pre>
           </div>
         </mat-tab>
       </mat-tab-group>
@@ -249,14 +249,14 @@
             <h4>Custom Directive for Display</h4>
             The gauge has three custom directives which can be used to modify the representation of the content displayed in the gauge
             which is beyond configuring just properties. For example, if you want to show an icon with the value to indicate increase or decrease is shown at the right.
-            <pre [highlight]="customMarkup1"></pre>
+            <pre [highlightAuto]="customMarkup1"></pre>
           </div>
         </mat-tab>
         <mat-tab label="Markup">
           <div class="content">
             This is the code for the demo shown on the right:
 
-            <pre [highlight]="customMarkup2"></pre>
+            <pre [highlightAuto]="customMarkup2"></pre>
           </div>
         </mat-tab>
       </mat-tab-group>
@@ -291,14 +291,14 @@
           <div class="content">
             This is the code for the demo shown on the right:
 
-            <pre [highlight]="gaugeWithMarkerMarkup"></pre>
+            <pre [highlightAuto]="gaugeWithMarkerMarkup"></pre>
           </div>
         </mat-tab>
         <mat-tab label="TypeScript">
           <div class="content">
             This is the code for the demo shown on the right:
 
-            <pre [highlight]="gaugeWithMarkerTS"></pre>
+            <pre [highlightAuto]="gaugeWithMarkerTS"></pre>
           </div>
         </mat-tab>
       </mat-tab-group>
@@ -341,14 +341,14 @@
           <div class="content">
             This is the code for the demo shown on the right:
 
-            <pre [highlight]="negativeThresholdMarkup"></pre>
+            <pre [highlightAuto]="negativeThresholdMarkup"></pre>
           </div>
         </mat-tab>
         <mat-tab label="TypeScript">
           <div class="content">
             This is the code for the demo shown on the right:
 
-            <pre [highlight]="negativeThresholdTS"></pre>
+            <pre [highlightAuto]="negativeThresholdTS"></pre>
           </div>
         </mat-tab>
       </mat-tab-group>

--- a/projects/demo/src/app/documentation/documentation.component.html
+++ b/projects/demo/src/app/documentation/documentation.component.html
@@ -167,6 +167,6 @@
         colors when gauge crosses certain value, use property thresholds. It takes an object with the threshold value as
         key and an object with color property as value. For example:
     </p>
-    <pre [highlight]="thresholdColors1"></pre>
-    <pre [highlight]="thresholdColors2"></pre>
+    <pre [highlightAuto]="thresholdColors1"></pre>
+    <pre [highlightAuto]="thresholdColors2"></pre>
 </div>

--- a/projects/demo/src/app/getting-started/getting-started.component.html
+++ b/projects/demo/src/app/getting-started/getting-started.component.html
@@ -23,18 +23,18 @@
   <h4>Installation</h4>
   <p> Installing and setup is super easy 3-step process. </p>
   <p><b>Step 1: Install npm module</b></p>
-  <pre [highlight]="step1Install" (highlighted)="onHighlight($event)"></pre>
+  <pre [highlightAuto]="step1Install" (highlighted)="onHighlight($event)"></pre>
 
   <p><b>Step 2: Import the <i>NgxGaugeModule</i> in your AppModule</b> <br>
     Make sure to import this module after BrowserModule as the import order matters.</p>
-  <pre [highlight]="step2Install"></pre>
+  <pre [highlightAuto]="step2Install"></pre>
 
   <p><b>Step 3: Use Gauge component in HTML template</b> <br>
     NgxGaugeModule provides a <i>ngx-gauge</i> component which can be used in any angular template to render a gauge.
     It's configuration properties can be bind to a typescript variable as shown below:
 
   </p>
-  <pre [highlight]="step3Install"></pre>
-  <pre [highlight]="step3Install2"></pre>
+  <pre [highlightAuto]="step3Install"></pre>
+  <pre [highlightAuto]="step3Install2"></pre>
 
 </div>


### PR DESCRIPTION
Migrates demo app to ngx-highlightjs v14 (compatible with Angular 19+).

Breaking changes addressed:
- v11: '[highlight]' directive renamed to '[highlightAuto]' (auto-detect). All 21 template usages migrated to '[highlightAuto]'. The new '[highlight]' directive requires an explicit 'language' input which the demo did not previously specify.
- v11: line-numbers split into a separate sub-package. The unused 'lineNumbersLoader' option (no template referenced it) is removed from HIGHLIGHT_OPTIONS.

Library code, tests, and coverage thresholds (90/80/90/90) unchanged. Supersedes Dependabot #205.