### PR TITLE
ci(deploy-demo): bump pages actions to v5 (Node 24)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: dist/demo/browser
 
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
actions/upload-pages-artifact@v4 transitively pinned actions/upload-artifact on Node.js 20, which GitHub is forcing to Node 24 on June 16, 2026 and removing entirely on Sept 16, 2026.

v5.0.0 of both upload-pages-artifact (Apr 2026) and deploy-pages (Mar 2026) run on Node 24 and reference current upload-artifact SHAs.