### PR TITLE
fix: round-cap with thresholds, marker labelColor, reading clip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `NgxGaugeMarker.labelColor?: string` — color used for a marker's label
+  text. Defaults to the marker's `color` when omitted, so labels stay
+  visible on dark themes and `line` markers no longer inherit whatever
+  `fillStyle` happened to be set from a previously drawn marker.
+  (#123, #145)
+
+### Fixed
+- `cap: 'round'` now also rounds the outer ends of the background bar when
+  `thresholds` are configured. Previously the segment loop forced
+  `lineCap: 'butt'` so only the foreground value bar was rounded; the
+  background ends stayed square. Two extra round-capped arcs are now
+  stroked at the leading edge of the first range and the trailing edge of
+  the last range, leaving inner segment joints untouched. (#127)
+- `.reading-block` and `.reading-label` no longer clip the top/bottom of
+  tall digits. The default `overflow` changed from `hidden` to `visible`
+  (and the now-inert `text-overflow: ellipsis` was removed). Consumers
+  that prefer the old clip-with-ellipsis behaviour for long
+  prepend/append text can restore it via a global style override (see
+  CSS comment in `gauge.css`). (#100)
+
 ## [13.3.0] - 2026-06-15
 
 ### Fixed

--- a/projects/ngx-gauge/src/gauge/gauge.css
+++ b/projects/ngx-gauge/src/gauge/gauge.css
@@ -4,14 +4,22 @@
     position: relative;
 }
 
+/*
+ * Issue #100: `overflow: hidden` on `.reading-block` / `.reading-label`
+ * clipped the top/bottom of tall digits (notably with rounded gauge fonts
+ * or large `[size]`). Default to `overflow: visible` so the value is shown
+ * fully. Long prepend/append strings will now overflow the gauge bounds
+ * instead of being ellipsized — consumers who need the ellipsis behaviour
+ * can override with `.ngx-gauge-meter .reading-block { overflow: hidden;
+ * text-overflow: ellipsis; }` in their global styles.
+ */
 .reading-block {
     position: absolute;
     width: 100%;
     font-weight: normal;
     white-space: nowrap;
     text-align: center;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow: visible;
 }
 
 .reading-label {
@@ -21,8 +29,7 @@
     position: absolute;
     text-align: center;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+    overflow: visible;
     font-weight: normal;
 }
 

--- a/projects/ngx-gauge/src/gauge/gauge.ts
+++ b/projects/ngx-gauge/src/gauge/gauge.ts
@@ -49,6 +49,13 @@ export interface NgxGaugeMarker {
     size?: number;
     label?: string;
     font?: string;
+    /**
+     * Issue #123 / #145: color used for the marker's label text. Defaults
+     * to `color` (the marker's stroke/fill color) when omitted, so labels
+     * are visible on dark themes and don't inherit a stale `fillStyle`
+     * from a previously drawn marker.
+     */
+    labelColor?: string;
 }
 
 export type NgxGaugeMarkers = Record<string, NgxGaugeMarker>;
@@ -295,6 +302,18 @@ export class NgxGauge implements AfterViewInit, OnChanges, OnDestroy, OnInit {
                     this._context.stroke();
                     this._context.globalAlpha = 1;
                 }
+                // Issue #127: when cap='round' is requested together with
+                // thresholds, the per-segment loop above must use 'butt' so
+                // inner joints stay clean. Restore the rounded outer ends by
+                // stroking a tiny arc with lineCap='round' at the very start
+                // of the first range and the very end of the last range. The
+                // round cap protrudes a half-linewidth past the endpoint —
+                // exactly the look users get without thresholds.
+                if (this.cap === 'round') {
+                    this._context.lineCap = 'round';
+                    this._drawThresholdEndCap(center.x, center.y, radius, ranges[0], 'start');
+                    this._drawThresholdEndCap(center.x, center.y, radius, ranges[ranges.length - 1], 'end');
+                }
             } else {
                 this._context.lineCap = this.cap;
                 this._context.beginPath();
@@ -331,7 +350,46 @@ export class NgxGauge implements AfterViewInit, OnChanges, OnDestroy, OnInit {
 
     }
 
-    private _addMarker(angle,color,label?,type?,len?,font?) {
+    /**
+     * Issue #127: draw a single rounded "end cap" at either edge of the
+     * thresholded background. Strokes a near-zero-length arc with
+     * `lineCap='round'` so only the cap is rendered. `which='start'` rounds
+     * the leading edge of the first range; `which='end'` rounds the
+     * trailing edge of the last range.
+     *
+     * `lineCap`, `lineWidth`, and globalAlpha bookkeeping are the caller's
+     * responsibility; this method only touches `strokeStyle`, `globalAlpha`,
+     * the path, and `stroke()`.
+     */
+    private _drawThresholdEndCap(
+        cx: number,
+        cy: number,
+        radius: number,
+        range: { color?: string; backgroundColor?: string; bgOpacity?: number; start: number; end: number },
+        which: 'start' | 'end'
+    ) {
+        const eps = 0.0001;
+        const angle = which === 'start'
+            ? this._getDisplacement(range.start)
+            : this._getDisplacement(range.end);
+        // Tiny arc: start cap protrudes back past `angle`, end cap protrudes
+        // forward. Either way the cap is what's visible.
+        const a0 = which === 'start' ? angle : angle - eps;
+        const a1 = which === 'start' ? angle + eps : angle;
+
+        this._context.beginPath();
+        this._context.strokeStyle = range.backgroundColor
+            ? range.backgroundColor
+            : (range.bgOpacity ? range.color : this.backgroundColor);
+        if (range.bgOpacity !== undefined && range.bgOpacity !== null) {
+            this._context.globalAlpha = range.bgOpacity;
+        }
+        this._context.arc(cx, cy, radius, a0, a1, false);
+        this._context.stroke();
+        this._context.globalAlpha = 1;
+    }
+
+    private _addMarker(angle,color,label?,type?,len?,font?,labelColor?) {
 
         const rad = angle * Math.PI / 180;
 
@@ -403,6 +461,10 @@ export class NgxGauge implements AfterViewInit, OnChanges, OnDestroy, OnInit {
             this._context.rotate((angle + 90) * (Math.PI / 180));
             this._context.textAlign = "center";
             this._context.font = (font) ? font : '13px Arial';
+            // Issue #123 / #145: set fillStyle explicitly so the label is
+            // visible on dark themes and doesn't inherit a stale value from
+            // a previously drawn marker. Defaults to the marker color.
+            this._context.fillStyle = labelColor ?? color ?? '#000';
             this._context.fillText(label,0,-3);
             this._context.restore();
         }
@@ -626,7 +688,7 @@ export class NgxGauge implements AfterViewInit, OnChanges, OnDestroy, OnInit {
                 const n = Number(mv) - this.min;
                 const angle = bounds.start + n * perD;
                 const m = this.markers[mv];
-                this._addMarker(angle,m.color,m.label,m.type,m.size,m.font);
+                this._addMarker(angle,m.color,m.label,m.type,m.size,m.font,m.labelColor);
             }
         }
     }

--- a/projects/ngx-gauge/test/gauge/gauge.drawing.spec.ts
+++ b/projects/ngx-gauge/test/gauge/gauge.drawing.spec.ts
@@ -49,7 +49,7 @@ class DrawingHost {
   margin: number | undefined = undefined;
   thresholds: { [k: string]: { color?: string; backgroundColor?: string; bgOpacity?: number } } = {};
   markers: {
-    [k: string]: { color?: string; label?: string; type?: 'line' | 'triangle'; size?: number; font?: string };
+    [k: string]: { color?: string; label?: string; type?: 'line' | 'triangle'; size?: number; font?: string; labelColor?: string };
   } = {};
   foregroundColor = '#0f0';
   backgroundColor = '#000';
@@ -273,14 +273,49 @@ describe('NgxGauge drawing pipeline — context-dependent methods', () => {
       expect(gauge._context.lineCap).toBe('round');
     });
 
-    it("uses lineCap='butt' when thresholds are configured", () => {
+    it("uses lineCap='butt' for the segment loop when thresholds are configured", () => {
       host.thresholds = { '0': { color: 'red' }, '50': { color: 'green' } };
       fixture.detectChanges();
       spyOnContext();
       gauge._drawShell(0, 1, 2, '#abc');
 
-      // Even if cap input is 'round', threshold rendering forces butt.
+      // Default cap is 'butt', so no round-cap pass runs; the final lineCap
+      // reflects the segment loop.
       expect(gauge._context.lineCap).toBe('butt');
+    });
+
+    // Issue #127: cap='round' + thresholds previously left the outer ends of
+    // the background bar square because the segment loop forces butt. Two
+    // extra round-capped arcs (one at the leading edge of the first range,
+    // one at the trailing edge of the last range) restore the rounded look.
+    it("Issue #127: cap='round' + thresholds: draws extra round-capped arcs at both outer ends", () => {
+      host.cap = 'round';
+      host.thresholds = { '0': { color: 'red' }, '50': { color: 'green' } };
+      fixture.detectChanges();
+      spyOnContext();
+      const ctx = gauge._context as any;
+
+      gauge._drawShell(0, 1, 2, '#abc');
+
+      // 2 segment arcs + 2 round-cap arcs + 1 foreground fill = 5
+      expect(ctx.arc).toHaveBeenCalledTimes(5);
+      // Final lineCap reflects the round-cap pass (last thing set).
+      expect(gauge._context.lineCap).toBe('round');
+      // globalAlpha still reset after each cap that uses bgOpacity.
+      expect(ctx.globalAlpha).toBe(1);
+    });
+
+    it("Issue #127: cap='butt' + thresholds: does NOT add extra cap arcs", () => {
+      host.cap = 'butt';
+      host.thresholds = { '0': { color: 'red' }, '50': { color: 'green' } };
+      fixture.detectChanges();
+      spyOnContext();
+      const ctx = gauge._context as any;
+
+      gauge._drawShell(0, 1, 2, '#abc');
+
+      // 2 segment arcs + 1 foreground fill = 3 (no cap pass)
+      expect(ctx.arc).toHaveBeenCalledTimes(3);
     });
 
     it("propagates 'thick' to ctx.lineWidth", () => {
@@ -404,6 +439,19 @@ describe('NgxGauge drawing pipeline — context-dependent methods', () => {
       expect(gauge._context.font).toContain('verdana');
     });
 
+    // Issue #123 / #145: label fillStyle is now set explicitly so labels
+    // stay visible on dark themes and don't inherit a stale fillStyle from
+    // a previously drawn marker.
+    it("Issue #123: defaults label fillStyle to the marker color when labelColor is omitted", () => {
+      gauge._addMarker(0, '#abc123', 'X');
+      expect(gauge._context.fillStyle).toBe('#abc123');
+    });
+
+    it("Issue #123: uses explicit labelColor when provided, independent of marker color", () => {
+      gauge._addMarker(0, '#abc123', 'X', undefined, undefined, undefined, '#ffffff');
+      expect(gauge._context.fillStyle).toBe('#ffffff');
+    });
+
     it('does not call fillText when no label is provided', () => {
       const ctx = gauge._context as any;
       gauge._addMarker(0, '#000');
@@ -439,9 +487,9 @@ describe('NgxGauge drawing pipeline — context-dependent methods', () => {
       }
     });
 
-    it('forwards marker color/label/type/size/font to _addMarker', () => {
+    it('forwards marker color/label/type/size/font/labelColor to _addMarker', () => {
       host.markers = {
-        '50': { color: 'cyan', label: 'mid', type: 'triangle', size: 12, font: '10px serif' },
+        '50': { color: 'cyan', label: 'mid', type: 'triangle', size: 12, font: '10px serif', labelColor: '#fff' },
       };
       fixture.detectChanges();
       spyOnContext();
@@ -455,6 +503,7 @@ describe('NgxGauge drawing pipeline — context-dependent methods', () => {
       expect(call[3]).toBe('triangle'); // type
       expect(call[4]).toBe(12); // size/len
       expect(call[5]).toBe('10px serif'); // font
+      expect(call[6]).toBe('#fff'); // labelColor (Issue #123 / #145)
     });
   });
 });


### PR DESCRIPTION
Bundles three small, independent bug fixes that share the same files.

## Closes

- Closes #127 — `cap: 'round'` leaves the outer ends of the background square when `thresholds` are configured
- Closes #123 — marker label color is fixed / inherits stale `fillStyle`
- Closes #145 — marker labels are invisible on dark themes (duplicate of #123, fixed by the same change)
- Closes #100 — top/bottom of tall digits in the reading value gets clipped

## Changes

### Fix #127 — round outer ends with thresholds
`projects/ngx-gauge/src/gauge/gauge.ts`

The per-segment loop in `_drawShell` must use `lineCap: 'butt'` so neighbouring threshold ranges don't render bumpy joints. Previously this meant the outer ends of the bar stayed square even when the user asked for `cap: 'round'` — only the foreground value bar was rounded, the background underneath was square.

After the segment loop, when `this.cap === 'round'`, we now stroke two tiny round-capped arcs via a new private `_drawThresholdEndCap` helper:

- one at `_getDisplacement(ranges[0].start)` (leading edge of the first range)
- one at `_getDisplacement(ranges[ranges.length - 1].end)` (trailing edge of the last range)

The arcs are ~zero-length so only the `lineCap: 'round'` half-circle is visible. Inner segment joints are untouched — they keep the existing butt caps and clean colour transitions. Each cap picks the same colour the segment loop chose for that range (`backgroundColor` → `color`+`bgOpacity` → `this.backgroundColor`), so opacity behaviour is preserved.

### Fix #123 / #145 — marker `labelColor`
`projects/ngx-gauge/src/gauge/gauge.ts`

`_addMarker` previously didn't set `fillStyle` before `fillText`, so the label inherited whatever `fillStyle` was last set:

- `type: 'triangle'` markers set `fillStyle = color` for the fill, so labels picked up the marker colour by accident.
- `type: 'line'` markers never set `fillStyle`, so labels inherited the previous marker's colour, or canvas default black — invisible on dark themes.

Changes:

- New optional field `NgxGaugeMarker.labelColor?: string`.
- `_drawMarkersAndTicks` plumbs `m.labelColor` through to `_addMarker`.
- `_addMarker` sets `this._context.fillStyle = labelColor ?? color ?? '#000'` explicitly right before `fillText`.

**Behaviour change**: `type: 'line'` markers with a `label` now render the label in the marker's `color` by default instead of inheriting an arbitrary `fillStyle`. This is strictly more predictable and matches what `type: 'triangle'` already did.

### Fix #100 — reading value clipped
`projects/ngx-gauge/src/gauge/gauge.css`

`.reading-block` and `.reading-label` had `overflow: hidden` + `text-overflow: ellipsis`, which clipped the top/bottom of tall digits for several reported font/size combinations. Default `overflow` is now `visible`; the now-inert `text-overflow: ellipsis` was removed.

**Trade-off**: very long `prepend` / `append` strings (e.g. multi-character units) will now overflow the gauge bounds instead of being ellipsized. Consumers who relied on the old clipping behaviour can restore it with a global style override:

```css
.ngx-gauge-meter .reading-block,
.ngx-gauge-meter .reading-label {
  overflow: hidden;
  text-overflow: ellipsis;
}