### PR TITLE
chore(tsconfig): drop deprecated baseUrl and dead outDir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
-    "baseUrl": "./",
-    "outDir": "./dist/out-tsc",
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "sourceMap": true,
@@ -14,16 +12,16 @@
     "target": "ES2022",
     "paths": {
       "ngx-gauge": [
-        "dist/ngx-gauge"
+        "./dist/ngx-gauge"
       ],
       "ngx-gauge/*": [
-        "dist/ngx-gauge/*"
+        "./dist/ngx-gauge/*"
       ]
     },
     "useDefineForClassFields": false
   },
   "exclude": [
     "**/*.spec.ts",
-    "dist/**"
+    "./dist/**"
   ]
 }


### PR DESCRIPTION
TypeScript 6 reports both options as deprecated for removal in TS 7:

- 'baseUrl' is no longer needed for 'paths' resolution (TS 4.1+). The two existing path mappings are switched to explicit relative form ('./dist/ngx-gauge', './dist/ngx-gauge/*') so they continue to resolve from the tsconfig's directory.
- 'outDir' at the root tsconfig was never used; every extending config (tsconfig.lib.json, tsconfig.lib.prod.json, tsconfig.app.json, tsconfig.spec.json) overrides it. Removing it also silences the rootDir warning that TS surfaces when no explicit rootDir is set.

'exclude' entry switched to './dist/**' for consistency with the new path style.

build:lib, lint, and test:ci all pass; no runtime / API surface change.