### PR TITLE
release: 13.3.1 — threshold round-cap, marker labelColor, value clip …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [13.3.1] - 2026-06-17
+
 ### Added
 - `NgxGaugeMarker.labelColor?: string` — color used for a marker's label
   text. Defaults to the marker's `color` when omitted, so labels stay
@@ -100,7 +102,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 See the [GitHub Releases](https://github.com/ashish-chopra/ngx-gauge/releases)
 page for the history of releases prior to `13.2.0`.
 
-[Unreleased]: https://github.com/ashish-chopra/ngx-gauge/compare/v13.3.0...HEAD
+[Unreleased]: https://github.com/ashish-chopra/ngx-gauge/compare/v13.3.1...HEAD
+[13.3.1]: https://github.com/ashish-chopra/ngx-gauge/compare/v13.3.0...v13.3.1
 [13.3.0]: https://github.com/ashish-chopra/ngx-gauge/compare/v13.2.0...v13.3.0
 [13.2.0]: https://github.com/ashish-chopra/ngx-gauge/compare/v13.1.0...v13.2.0
 [13.1.0]: https://github.com/ashish-chopra/ngx-gauge/releases/tag/v13.1.0

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In version `v5.0.0`, we introduced markers, ticks and background opacity for gau
 |18.x.x | 10.0.0 |
 |19.x.x | 11.0.0 |
 |20.x.x | 12.0.0 |
-|21.x.x | 13.2.0 |
+|21.x.x | 13.3.1 |
 
 #### Step 1: Install npm module
 
@@ -79,7 +79,7 @@ import { Component } from '@angular/core';
     templateUrl: 'app.html'
 })
 export class AppComponent {
-    
+
     gaugeType = "semi";
     gaugeValue = 28.3;
     gaugeLabel = "Speed";
@@ -88,9 +88,9 @@ export class AppComponent {
 ```
 
 ```html
-<ngx-gauge [type]="gaugeType" 
-           [value]="gaugeValue" 
-           [label]="gaugeLabel"  
+<ngx-gauge [type]="gaugeType"
+           [value]="gaugeValue"
+           [label]="gaugeLabel"
            [append]="gaugeAppendText">
 </ngx-gauge>
 ```
@@ -173,7 +173,7 @@ Note that `value` attribute is still required on `<ngx-gauge>` even when you are
 
 <!-- # Playground
 
-The examples section is redesigned as a playground where you can play with Gauge by tuning its different parameters. 
+The examples section is redesigned as a playground where you can play with Gauge by tuning its different parameters.
 And, you can see the result live on-screen. It is good start to get familiar with Gauge.
 
 ![alt text](https://raw.githubusercontent.com/ashish-chopra/angular-gauge/master/examples/playground.png)
@@ -193,7 +193,7 @@ $> npm install
 2. Use following commands based on what you'd like to do:
 
 ```shell
-$> npm start             # builds the project and watch for changes. 
+$> npm start             # builds the project and watch for changes.
 $> npm test              # runs test suite once and exit.
 $> npm run test:watch    # starts the test framework and watch for changes in code.
 $> npm run build         # triggers a manual build for library, outputs at `/dist` directory.

--- a/projects/ngx-gauge/package.json
+++ b/projects/ngx-gauge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ngx-gauge",
-    "version": "13.3.0",
+    "version": "13.3.1",
     "description": "A highly customizable Gauge Component for Angular 4+ apps and dashboards",
     "repository": {
         "type": "git",


### PR DESCRIPTION
Release-prep PR for `13.3.1`.

## What's in this release

Bug fixes from #224 (already on `master`):

- **#127** — `cap: 'round'` now also rounds the outer ends of the background bar when `thresholds` are configured.
- **#123 / #145** — `NgxGaugeMarker.labelColor?: string` added; marker labels default to the marker's `color` (visible on dark themes; line markers no longer inherit a stale `fillStyle`).
- **#100** — `.reading-block` / `.reading-label` default `overflow` is now `visible` so tall digits aren't clipped. Documented override for consumers who want the old ellipsis behaviour.

## Changes in this PR

- `projects/ngx-gauge/package.json` — version `13.3.0` → `13.3.1`
- `CHANGELOG.md` — promote the `[Unreleased]` block to `## [13.3.1] - 2026-06-17`; add fresh empty `[Unreleased]`; add `[13.3.1]` compare-link and update `[Unreleased]` compare-link to `v13.3.1...HEAD`
- `README.md` — compatibility table row: Angular `21.x.x` ↔ ngx-gauge `13.3.1`

No source/test changes.

## After merge

1. Draft a new GitHub Release with tag `v13.3.1`, targeting `master`.
2. Paste the `[13.3.1]` CHANGELOG section as the release notes.
3. Publish — the `release.yml` workflow picks up the `release: published` event and publishes to npm with provenance.